### PR TITLE
 fixed typo

### DIFF
--- a/web/demo/templates/menu_start.html
+++ b/web/demo/templates/menu_start.html
@@ -8,7 +8,7 @@ In the nineteenth century there were more than 800 municipalities in the Netherl
 <tr>
 <td width="48%">
 <h2>Key Features</h2>
-The project's aim is twofold: to allow non-GIS experts to easily plot data on historical maps and to disseminate information on the maps and the underlying data from the Histrocial Database of Dutch Municipalities (HDNG). We do so in the following manner:
+The project's aim is twofold: to allow non-GIS experts to easily plot data on historical maps and to disseminate information on the maps and the underlying data from the Historicial Database of Dutch Municipalities (HDNG). We do so in the following manner:
 	<li>Upload your own datasets and visualize the data on historically accurate map boundaries</li>
 	<li>Get access to the map of Netherlands on the <a href="/site?code=TXGE&year=1982&province=Noord-Holland">provincial level</a></li>
 	<li>Download the map in Vector (<a href="/download?year=1982&province=&code=TXGE&format=SVG">SVG</a>, <a href="/download?year=1982&province=&code=TXGE&format=shapefile">ShapeFile</a>) or Raster quality (<a href="/download?year=1982&code=TXGE">PNG</a>, <a href="/download?year=1982&province=&code=TXGE&format=PDF">PDF</a>)</li>


### PR DESCRIPTION
Fixed the following typo on ‘homepage’. See issue #18

Historical <- Histrocial
